### PR TITLE
repaired date range in ajax, altered date selector in HTML

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -85,6 +85,7 @@ $('#rest-btn').on('click', function(){
 
 //MOVIE GENERATOR
 
+
 function getTitle() {
 
     var tmdbArr = [];
@@ -92,11 +93,11 @@ function getTitle() {
     var endYear = $("#end-year-input").val();
 
     $.ajax({
-        url: "https://api.themoviedb.org/3/discover/movie?api_key=183cf14b0fa970fabe87a2879d2f3aa1&language=en-US&sort_by=popularity.desc&include_adult=false&include_video=false&page=1&release_date.gte=1981-01-01&release_date.lte=1982-01-01&with_genres=80",
+        url: "https://api.themoviedb.org/3/discover/movie?api_key=183cf14b0fa970fabe87a2879d2f3aa1&language=en-US&sort_by=popularity.desc&include_adult=false&include_video=false&page=1&primary_release_date.gte=1981-01-01&primary_release_date.lte=1982-01-01&with_genres=80",
         method: "GET",
       }).then(function(response) {
         
-        for (var i = 0; i < 1; i++) {
+        for (var i = 0; i < 3; i++) {
 
         getMovieDetails(response.results[i].title)
 

--- a/index.html
+++ b/index.html
@@ -133,7 +133,10 @@
             </div>
             <div class="col-md-6  movie-inputs">
               <!-- Decade Input -->
-              <div class="mb-4">
+
+
+
+              <!-- <div class="mb-4">
                 <h3 class="decade-header">Decades to Include:</h3>
                 <div class="form-check">
                   <input class="form-check-input" type="checkbox" value="2020-01-01" id="decade1">
@@ -177,9 +180,25 @@
                     1960s
                   </label>
                 </div>
-              </div>
+              </div> -->
             
               <!-- Genre Input -->
+
+              <h3 class="date-selector">Show me movies from</h3>
+              <div class="input-group input-group-lg">
+                <div class="input-group-prepend">
+                  <span class="input-group-text" id="inputGroup-sizing-default">Earliest Year</span>
+                </div>
+                <input type="text" class="form-control earliest-year-selector" aria-label="Sizing example input" aria-describedby="inputGroup-sizing-default">
+              </div>
+              <h3 class="date-selector">until</h3>
+              <div class="input-group input-group-lg">
+                <div class="input-group-prepend ">
+                  <span class="input-group-text" id="inputGroup-sizing-default">Latest Year</span>
+                </div>
+                <input type="text" class="form-control latest-year-selector" aria-label="Sizing example input" aria-describedby="inputGroup-sizing-default">
+              </div>
+              <h3 class="genre-selector">that are about...</h3>
               <div class="input-group input-group-lg mb-4">
                 <div class="input-group-prepend">
                   <label class="input-group-text" for="inputGroupSelect01">Genre</label>


### PR DESCRIPTION
Ran into issues querying the release date range with checkboxes, if there's a gap in decades then only one decade's results will populate (i.e. you can't view selections from the 1970s and 1990s but not the 1980s.

I commented out the checkboxes in the HTML in case we go back to them, and replaced them with an input group.  We can test to ensure the user enters an integer and use the results for our date range.